### PR TITLE
Wrong error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,15 +33,19 @@ function main(name: string): void {
       basicAuthToken = getBasicAuthToken(username, githubAccessToken)
     }
 
-    const exists = yield checkIfRepoExists(name, basicAuthToken)
+    const { wrongCredentials, repoExists } = yield checkIfRepoExists(name, basicAuthToken)
     const dir = `./${name}`
 
     if (fs.existsSync(dir)) {
       console.log(chalk.bold.red(`A folder with the name ${name} already exists in this folder..`))
       process.exit(0)
     }
-    if (exists) {
+    if (repoExists) {
       console.log(chalk.bold.red(`A repository with the name ${name} already exists on your github account..`))
+      process.exit(0)
+    }
+    if (wrongCredentials) {
+      console.log(chalk.bold.red(`Hey! You got your credentials all wrong ${username}!`))
       process.exit(0)
     }
     fs.mkdirSync(dir)

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -29,5 +29,8 @@ export function checkIfRepoExists(name: string, accessToken: string): Promise<bo
       `${GITHUB_API_BASE_URL}/user/repos/${name}`, 
       {method: 'GET', headers}
     )
-    .then(({ status }) => status)
+    .then(({ status }) => ({
+      wrongCredentials: status === 401,
+      repoExists: status === 404,
+    }))
 }

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -29,5 +29,5 @@ export function checkIfRepoExists(name: string, accessToken: string): Promise<bo
       `${GITHUB_API_BASE_URL}/user/repos/${name}`, 
       {method: 'GET', headers}
     )
-    .then(res => res.status !== 404)
+    .then(({ status }) => status)
 }


### PR DESCRIPTION
Used to tell the user: "That repo already exists", if the wrong credentials were entered. Now it tells the user that the credentials were wrong. :rocket:  